### PR TITLE
83 - Fix window that used to be always on top

### DIFF
--- a/src/Launcher/LauncherWindow.java
+++ b/src/Launcher/LauncherWindow.java
@@ -12,7 +12,6 @@ public class LauncherWindow extends JFrame {
     public LauncherWindow() {
         this.setTitle(LauncherWindow.TITLE);
         this.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-        this.setAlwaysOnTop(true);
         this.setFocusable(true);
 
         // dimensions and location


### PR DESCRIPTION
# Development Objective
The window used to be always on top

**Related to #84**

# Screenshots
<img width="945" alt="capture d ecran 2018-11-29 a 22 04 59" src="https://user-images.githubusercontent.com/20768914/49251876-d1c1bb00-f422-11e8-9477-5017ca552a13.png">
Now my finder is above the game window 👍
