### PR TITLE
114 - scale   layer icon runner

### DIFF
--- a/src/Game/Games/Runner/RunnerView/PlayerControls.java
+++ b/src/Game/Games/Runner/RunnerView/PlayerControls.java
@@ -1,11 +1,14 @@
 package Game.Games.Runner.RunnerView;
 
 import Player.Player;
+import Utils.Image.ImageResizer;
 
 import javax.swing.*;
 import java.awt.*;
 
 public class PlayerControls extends JPanel {
+
+    private static final int PLAYER_ICON_SIZE = 80;
 
     private final JLabel playerIcon;
     private final VirtualKey leftKey;
@@ -25,7 +28,7 @@ public class PlayerControls extends JPanel {
         constraint.gridwidth = 2;
         constraint.gridheight = 1;
         this.playerIcon = new JLabel(
-            player.getIcon()
+            ImageResizer.resizeImage(player.getIcon(), PlayerControls.PLAYER_ICON_SIZE)
         );
         this.add(this.playerIcon, constraint);
 


### PR DESCRIPTION
# Development Objective
Set a default size for player icons in the runner view

**Related to #114**

# Comment

# Screenshots
<img width="912" alt="capture d ecran 2018-12-03 a 12 35 08" src="https://user-images.githubusercontent.com/20768914/49371487-dffc2980-f6f7-11e8-956e-9f568b2f9ca0.png">

