### PR TITLE
134 - Contest settings validation rule for name

### DIFF
--- a/src/ContestSettings/Model/ContestSettingsModel.java
+++ b/src/ContestSettings/Model/ContestSettingsModel.java
@@ -32,11 +32,11 @@ public class ContestSettingsModel extends AbstractModel {
         this.invalidDataObjectText = "";
 
         if (settingsDataObject.getSelectedGameTypes().isEmpty()) {
-            this.invalidDataObjectText = "At least one game type has to be selected<br>";
+            this.invalidDataObjectText += "At least one game type has to be selected<br>";
         }
 
         if (settingsDataObject.getFirstPlayerName().equals(settingsDataObject.getSecondPlayerName())) {
-            this.invalidDataObjectText = "Both player can't have the same name<br>";
+            this.invalidDataObjectText += "Both player can't have the same name<br>";
         }
 
         if (settingsDataObject.getFirstPlayerColor() == settingsDataObject.getSecondPlayerColor()) {
@@ -55,6 +55,6 @@ public class ContestSettingsModel extends AbstractModel {
      * @return Invalid settings DTO text
      */
     public String getInvalidDataObjectText() {
-        return invalidDataObjectText;
+        return this.invalidDataObjectText;
     }
 }


### PR DESCRIPTION
# Development Objective
Rule added for the validation of the name of players in the contest settings.
The rule is: 2 players can't use the same name

**Related to #134**

# Screenshots
<img width="912" alt="capture d ecran 2018-12-04 a 13 00 30" src="https://user-images.githubusercontent.com/20768914/49440688-9594ae80-f7c4-11e8-97f4-a432bbe9b237.png">
