### PR TITLE
89 - Cleanup datajson

### DIFF
--- a/src/Menu/View/MenuView.java
+++ b/src/Menu/View/MenuView.java
@@ -1,15 +1,19 @@
 package Menu.View;
 
 import Launcher.LauncherWindow;
+import Player.Player;
+import Repository.Player.PlayerRepository;
 import Scene.Model.ActionEnum;
 import Utils.Image.ImageResizer;
 import Utils.UI.CustomButton;
 import Utils.UI.CustomPanel.CustomBackgroundPanel;
+import Utils.UI.FileGetter;
 
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.util.List;
 
 public class MenuView extends CustomBackgroundPanel {
 
@@ -63,6 +67,11 @@ public class MenuView extends CustomBackgroundPanel {
         constraint.gridx = 0;
         constraint.gridy = 3;
         constraint.gridwidth = 2;
+        List<Player> players = PlayerRepository.getAll();
+        if (players.isEmpty()) {
+            this.statisticsButton.setEnabled(false);
+            ((CustomButton) this.statisticsButton).setBackgroundGrey();
+        }
         this.add(this.statisticsButton, constraint);
         constraint.gridwidth = 1;
 

--- a/src/Utils/UI/CustomButton.java
+++ b/src/Utils/UI/CustomButton.java
@@ -10,7 +10,9 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.MouseInputAdapter;
 import java.awt.*;
+import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
 import java.awt.image.BufferedImage;
 
 public class CustomButton extends JButton {
@@ -168,5 +170,13 @@ public class CustomButton extends JButton {
     private void setBackgroundPressed() {
         this.yOffset = CustomButton.Y_OFFSET;
         this.backgroundImage = FileGetter.getImage("_button01.png");
+    }
+
+    public void setBackgroundGrey() {
+        for (MouseListener current : this.getMouseListeners()) {
+            this.removeMouseListener(current);
+        }
+
+        this.backgroundImage = FileGetter.getGreyImage("_button00.png");
     }
 }

--- a/src/data/JSON/jsondata.json
+++ b/src/data/JSON/jsondata.json
@@ -34,35 +34,10 @@
     },
     {
       "name": "TIC_TAC_TOE_BEST_PLAYER",
-      "value": "Bastos"
+      "value": "NONE"
     }
   ],
-  "players": [
-    {
-      "color": "BLUE",
-      "name": "j2",
-      "icon": "BATMAN",
-      "statistics": {
-        "TIC_TAC_TOE_NB_GAME":"0",
-        "TIC_TAC_TOE_NB_WIN":"0",
-        "TIC_TAC_TOE_WIN_RATE":"0",
-        "RUNNER_NB_GAME":"0",
-        "RUNNER_NB_WIN":"0",
-        "RUNNER_WIN_RATE":"0",
-        "CONNECT_FOUR_NB_GAME":"0",
-        "CONNECT_FOUR_NB_WIN":"0",
-        "CONNECT_FOUR_WIN_RATE":"0",
-        "COOKIE_CLICKER_NB_GAME":"0",
-        "COOKIE_CLICKER_NB_WIN":"0",
-        "COOKIE_CLICKER_WIN_RATE":"0",
-        "MOST_PLAYED_GAME":"NONE",
-        "TOTAL_NB_GAME":"0",
-        "TOTAL_NB_WIN":"0",
-        "TOTAL_NB_LOOSE":"0",
-        "WIN_RATE":"0"
-      }
-    }
-  ],
+  "players": [],
   "cookieClicker": [
     {
       "name": "COOKIE_CLICKER_NB_GAMES",
@@ -74,7 +49,7 @@
     },
     {
       "name": "COOKIE_CLICKER_BEST_PLAYER",
-      "value": "EliasZER"
+      "value": "NONE"
     },
     {
       "name": "COOKIE_CLICKER_NB_PERFECT",
@@ -112,7 +87,7 @@
     },
     {
       "name": "CONNECT_FOUR_BEST_PLAYER",
-      "value": "RayaneLeMarco1"
+      "value": "NONE"
     },
     {
       "name": "CONNECT_FOUR_NB_YELLOW_PAWNS",
@@ -170,7 +145,7 @@
     },
     {
       "name": "RUNNER_BEST_PLAYER",
-      "value": "Floflax"
+      "value": "NONE"
     }
   ]
 }


### PR DESCRIPTION
# Development Objective
- Cleanup the jsondata
- Disable the statistics menu when no player is present in database

**Related to #89**

# Comment
When there is no player in the database, the statistics menu should not be accessible.

# Screenshots
<img width="350" alt="capture d ecran 2018-12-18 a 18 29 16" src="https://user-images.githubusercontent.com/17028390/50171469-d4f9e980-02f2-11e9-8bfb-e84d450cfccd.png">

